### PR TITLE
Optimizing the t-route installation method for a Python virtual environment. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+echo "--- Starting t-route Installation ---"
+
+# If on a cluster platform that requires module load
+# commands to load up python, cmake, netcdf, and/or gcc
+# then go ahead and insert those moudle commands here. 
+# Below are example moudle load commnads for the NOAA
+# RDHPCS Ursa cluster
+module purge
+module load hpcx-mpi/2.18.1
+module load netcdf-fortran/4.6.1
+module load cmake/3.30.2
+module load python/3.11
+
+
+
+# User defined installation pathway to the virtual Python
+# for t-route needs to be set here! Otherwise, default is 
+# in the t-route root directory
+INSTALL_DIR=$(pwd)
+
+# System dependency check to ensure we have all the required
+# compilers and libraries for t-route
+dependencies=("gcc" "gfortran" "cmake" "python3" "nc-config" "nf-config")
+
+for tool in "${dependencies[@]}"; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo "Error: $tool is not installed or not in PATH."
+        echo "Please install the missing dependency before running the t-route installation script."
+        exit 1
+    fi
+done
+
+# Set compiler definitions based on user defined environmental variables 
+# or defer to standard defaults
+export FC=${FC:-gfortran}
+export CC=${CC:-gcc}
+export CXX=${CXX:-g++}
+
+
+# Create virtual environment
+if [ ! -d "venv" ]; then
+    echo "Creating virtual Python environment for t-route..."
+    python3 -m venv venv
+fi
+
+
+# Automatically extract paths from the system's NetCDF installation
+NC_LIB_PATH=$(nc-config --prefix)/lib
+NF_LIB_PATH=$(nf-config --prefix)/lib
+NC_INC=$(nc-config --includedir)
+
+# Set Linker flags so the compiler knows where the NetCDF binaries live
+export LDFLAGS="-L${NC_LIB_PATH} -L${NF_LIB_PATH} -Wl,-rpath,${NC_LIB_PATH} -Wl,-rpath,${NF_LIB_PATH}"
+export NETCDF="${NC_INC}"
+
+
+echo "Installing t-route libraries and it's internal dependencies..."
+
+# Activate Python virtual environment, install baseline
+# Python dependencies for t-route libraries, and then 
+# install the t-route libraries for Python
+source $INSTALL_DIR/venv/bin/activate && \
+$INSTALL_DIR/venv/bin/pip install --upgrade pip~=24.0 && \
+$INSTALL_DIR/venv/bin/pip install -r requirements.txt && \
+env LDFLAGS="$(nc-config --libs) $(nf-config --flibs)" NETCDF=$(nc-config --includedir) ./compiler.sh no-e
+
+echo "--- Installation Complete! ---"
+

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -1,5 +1,18 @@
-NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
-NETCDFLIB := $(shell nc-config --flibs)
+NF_CONFIG := $(shell command -v nf-config 2> /dev/null)
+
+ifdef NF_CONFIG
+    # Modern approach (NetCDF-Fortran separated from NetCDF-C)
+    NETCDFINC_FLAGS := $(shell nf-config --fflags)
+    NETCDFLIB_FLAGS := $(shell nf-config --flibs)
+else
+    # Legacy fallback for older versions or monolithic installs
+    NETCDFINC_FLAGS := $(shell nc-config --fflags 2> /dev/null || nc-config --cflags)
+    NETCDFLIB_FLAGS := $(shell nc-config --flibs 2> /dev/null || nc-config --libs)
+endif
+
+NETCDFINC := -I$(NETCDFINC) $(NETCDFINC_FLAGS)
+NETCDFLIB := $(NETCDFLIB_FLAGS)
+
 COMPILER90 = $(F90)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 


### PR DESCRIPTION
This PR attempts to address the `t-route/src/kernel/reservoir/makefile` deficiency of properly accounting for `nf-config` and `nc-config` argument calls based on netcdf4 version control. This also includes an installations script called `install.sh` that will allow users to properly install a Python virtual environment for t-route without have to decipher the complexities of using the `compiler.sh` script. 

## Additions

- `install.sh` script in t-route root directory. 

## Removals

- None

## Changes

- `t-route/src/kernel/reservoir/makefile` calls to the `nc-config` and `nf-config` executables based on availability of tools. 


