### PR TITLE
Patching Compilation of T-Route with Intel Compilers for Fortran

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -12,15 +12,21 @@ build_routing=true
 build_config=true
 build_nwm=true
 
-if [ -z "$F90" ]
+
+if [ -z "$FC" ]
 then
-    export F90="gfortran"
-    echo "using F90=${F90}"
+    FC=gfortran
+    echo "FC environmental variable not set. Defaulting to FC=${FC}"
+else
+    echo "Using environmental Fortran compiler: FC=${FC}"
 fi
+
 if [ -z "$CC" ]
 then
-    export CC="gcc"
-    echo "using CC=${CC}"
+    CC=gcc
+    echo "CC environmental variable not set. Defaulting to CC=${CC}"
+else
+    echo "Using environmental C compiler: CC=${CC}"
 fi
 
 #preserve old/default behavior of installing packages with -e

--- a/install.sh
+++ b/install.sh
@@ -6,15 +6,32 @@ set -e
 echo "--- Starting t-route Installation ---"
 
 # If on a cluster platform that requires module load
-# commands to load up python, cmake, netcdf, and/or gcc
-# then go ahead and insert those moudle commands here. 
-# Below are example moudle load commnads for the NOAA
-# RDHPCS Ursa cluster
+# commands to load up python, cmake, netcdf, and gcc 
+# or intel compilers and then go ahead and insert 
+# those module commands here. Below are example 
+# module load commands for the NOAA RDHPCS Ursa cluster
 module purge
-module load hpcx-mpi/2.18.1
+
+####### gcc/gfortran compilers ##############
+#module load hpcx-mpi/2.18.1
+#module load netcdf-fortran/4.6.1
+#module load cmake/3.30.2
+#module load python/3.11
+#export FC=gfortran
+#export CC=gcc
+#export CXX=g++
+############################################
+
+####### intel compilers ####################
+module load intel-oneapi-compilers/2025.1.1
+module load intel-oneapi-mpi/2021.15.0
 module load netcdf-fortran/4.6.1
 module load cmake/3.30.2
 module load python/3.11
+export FC=mpiifx
+export CC=mpiicx
+export CXX=mpiicpx
+############################################
 
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+echo "--- Starting t-route Installation ---"
+
+# If on a cluster platform that requires module load
+# commands to load up python, cmake, netcdf, and/or gcc
+# then go ahead and insert those moudle commands here. 
+# Below are example moudle load commnads for the NOAA
+# RDHPCS Ursa cluster
+module purge
+module load hpcx-mpi/2.18.1
+module load netcdf-fortran/4.6.1
+module load cmake/3.30.2
+module load python/3.11
+
+
+
+# User defined installation pathway to the virtual Python
+# for t-route needs to be set here! Otherwise, default is 
+# in the t-route root directory
+INSTALL_DIR=$(pwd)
+
+# System dependency check to ensure we have all the required
+# compilers and libraries for t-route
+dependencies=("gcc" "gfortran" "cmake" "python3" "nc-config" "nf-config")
+
+for tool in "${dependencies[@]}"; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo "Error: $tool is not installed or not in PATH."
+        echo "Please install the missing dependency before running the t-route installation script."
+        exit 1
+    fi
+done
+
+# Set compiler definitions based on user defined environmental variables 
+# or defer to standard defaults
+export FC=${FC:-gfortran}
+export CC=${CC:-gcc}
+export CXX=${CXX:-g++}
+
+
+# Create virtual environment
+if [ ! -d "venv" ]; then
+    echo "Creating virtual Python environment for t-route..."
+    python3 -m venv venv
+fi
+
+
+# Automatically extract paths from the system's NetCDF installation
+NC_LIB_PATH=$(nc-config --prefix)/lib
+NF_LIB_PATH=$(nf-config --prefix)/lib
+NC_INC=$(nc-config --includedir)
+
+# Set Linker flags so the compiler knows where the NetCDF binaries live
+export LDFLAGS="-L${NC_LIB_PATH} -L${NF_LIB_PATH} -Wl,-rpath,${NC_LIB_PATH} -Wl,-rpath,${NF_LIB_PATH}"
+export NETCDF="${NC_INC}"
+
+
+echo "Installing t-route libraries and it's internal dependencies..."
+
+# Activate Python virtual environment, install baseline
+# Python dependencies for t-route libraries, and then 
+# install the t-route libraries for Python
+source $INSTALL_DIR/venv/bin/activate && \
+$INSTALL_DIR/venv/bin/pip install --upgrade pip~=24.0 && \
+$INSTALL_DIR/venv/bin/pip install -r requirements.txt && \
+env LDFLAGS="$(nc-config --libs) $(nf-config --flibs)" NETCDF=$(nc-config --includedir) ./compiler.sh no-e
+
+echo "--- Installation Complete! ---"
+

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ T-Route represents streamflow channel routing and reservoir routing, assimilatin
 This program uses the following system packages:
 ```
 python3
-gcc-gfortran
+gcc-gfortran OR Intel compilers
 ```
 
 ... and the following non-default python modules:
@@ -89,8 +89,14 @@ pip3 install numpy pandas xarray netcdf4 joblib toolz pyyaml Cython>3,!=3.0.4 ge
 # clone t-toute
 git clone --progress --single-branch --branch master http://github.com/NOAA-OWP/T-Route.git
 
+## Installation Option 1 for direct installation using precompiled Python environment
 # compile and install
 ./compiler.sh
+
+## Installation Option 2 to install a virtual Python environment for t-route modules
+# compile and install
+./install.sh
+
 
 # execute a demonstration test with NHD network
 cd test/LowerColorado_TX

--- a/src/kernel/diffusive/makefile
+++ b/src/kernel/diffusive/makefile
@@ -1,15 +1,18 @@
 # compiler
-FC := ${F90}
+FC := ${FC}
 
 # compile flags
 F90FLAGSGFORTRAN = -g -c -O2 -fPIC -fbounds-check 
 F90FLAGSINTEL = -free -g -c -O2 -fPIC -I${NETCDF}/include 
-ifeq ($(notdir ${FC}), ifort)
-FCFLAGS = $(F90FLAGSINTEL)
-else ifeq ($(notdir ${FC}), mpiifort)
-FCFLAGS = $(F90FLAGSINTEL)
+
+FC_VERSION := $(shell $(FC) --version 2>&1 || true)
+
+IS_INTEL := $(findstring Intel,$(FC_VERSION))$(findstring ifx,$(FC_VERSION))$(findstring ifort,$(FC_VERSION))
+
+ifneq ($(strip $(IS_INTEL)),)
+    FCFLAGS = $(F90FLAGSINTEL)
 else
-FCFLAGS = $(F90FLAGSGFORTRAN)
+    FCFLAGS = $(F90FLAGSGFORTRAN)
 endif
 
 diffusive.o: diffusive.f90

--- a/src/kernel/muskingum/makefile
+++ b/src/kernel/muskingum/makefile
@@ -1,18 +1,20 @@
 # compiler
-FC := $(F90)
+FC := $(FC)
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
 F90FLAGSGFORTRAN = -g -c -O2 -fPIC -lgfortran -lgcc -static-libgfortran -static-libgcc -nodefaultlibs
 F90FLAGSINTEL = -free -w -c -O2 -fPIC -fconvert=big-endian -frecord-marker=4
-ifeq ($(notdir ${FC}), ifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else ifeq ($(notdir ${FC}), mpiifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else
-F90FLAGS = $(F90FLAGSGFORTRAN)
-endif
 
+FC_VERSION := $(shell $(FC) --version 2>&1 || true)
+
+IS_INTEL := $(findstring Intel,$(FC_VERSION))$(findstring ifx,$(FC_VERSION))$(findstring ifort,$(FC_VERSION))
+
+ifneq ($(strip $(IS_INTEL)),)
+    F90FLAGS = $(F90FLAGSINTEL)
+else
+    F90FLAGS = $(F90FLAGSGFORTRAN)
+endif
 
 .PHONY: reach all install
 all: reach 

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -13,17 +13,20 @@ endif
 NETCDFINC := -I$(NETCDFINC) $(NETCDFINC_FLAGS)
 NETCDFLIB := $(NETCDFLIB_FLAGS)
 
-COMPILER90 = $(F90)
+FC = $(FC)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 
 F90FLAGSINTEL = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4
-ifeq ($(notdir ${FC}), ifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else ifeq ($(notdir ${FC}), mpiifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else
-F90FLAGS = $(F90FLAGSGFORTRAN)
-endif
+
+FC_VERSION := $(shell $(FC) --version 2>&1 || true)
+
+IS_INTEL := $(findstring Intel,$(FC_VERSION))$(findstring ifx,$(FC_VERSION))$(findstring ifort,$(FC_VERSION))
+
+ifneq ($(strip $(IS_INTEL)),) 
+    F90FLAGS = $(F90FLAGSINTEL)
+else     
+    F90FLAGS = $(F90FLAGSGFORTRAN)
+endif 
 
 F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB)  -nodefaultlibs -fPIC
 ARFLAGS = rc
@@ -35,10 +38,10 @@ VPATH = ./Level_Pool ./Persistence_Level_Pool_Hybrid ./RFC_Forecasts
 all: binding_lp.a bind_hybrid.a bind_rfc.a
 
 test_main: test_main.o binding_lp.a bind_hybrid.a bind_rfc.a
-	$(COMPILER90) -g -o $@ $^
+	$(FC) -g -o $@ $^
 
 test_main.o: test_binding.c
-	$(COMPILER90) -g -c -o $@ $<
+	$(FC) -g -c -o $@ $<
 
 module_levelpool.o: module_reservoir.o module_levelpool_properties.o module_levelpool_state.o
 
@@ -62,10 +65,10 @@ bind_rfc.a: module_reservoir.o module_hydro_stop.o module_reservoir_utilities.o 
 	$(AR) $(ARFLAGS) $@ $^
 
 %.o: %.F
-	$(COMPILER90) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
+	$(FC) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
 
 %.o: %.f90
-	$(COMPILER90) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
+	$(FC) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
 
 #install: binding_lp.a bind_hybrid.a bind_rfc.a
 #install: binding_lp.a bind_rfc.a

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -13,7 +13,7 @@ endif
 NETCDFINC := -I$(NETCDFINC) $(NETCDFINC_FLAGS)
 NETCDFLIB := $(NETCDFLIB_FLAGS)
 
-FC = $(FC)
+FC := $(FC)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 
 F90FLAGSINTEL = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -1,5 +1,18 @@
-NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
-NETCDFLIB := $(shell nc-config --flibs)
+NF_CONFIG := $(shell command -v nf-config 2> /dev/null)
+
+ifdef NF_CONFIG
+    # Modern approach (NetCDF-Fortran separated from NetCDF-C)
+    NETCDFINC_FLAGS := $(shell nf-config --fflags)
+    NETCDFLIB_FLAGS := $(shell nf-config --flibs)
+else
+    # Legacy fallback for older versions or monolithic installs
+    NETCDFINC_FLAGS := $(shell nc-config --fflags 2> /dev/null || nc-config --cflags)
+    NETCDFLIB_FLAGS := $(shell nc-config --flibs 2> /dev/null || nc-config --libs)
+endif
+
+NETCDFINC := -I$(NETCDFINC) $(NETCDFINC_FLAGS)
+NETCDFLIB := $(NETCDFLIB_FLAGS)
+
 COMPILER90 = $(F90)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 


### PR DESCRIPTION
### Summary

- Updated `README.md` documentation to include intel compiler options, including extra instructions for installing Python virtual environment using the `install.sh` script. 
- Updated `install.sh` script to include an example of an intel compiler suite on Ursa for compiling T-Route. 
- Modified the `compiler.sh` script to find `$FC` and `$CC `environmental variables specified by a user or just default to standard `gcc` and `gfortran `compilers. 
- Modified reservoir, diffusive and muskingum Makefiles to dynamically set flags for `intel` or `gcc/gfortran` based on metadata from the $FC environmental variable. 

Altogether, these changes have been verified to successfully install and run T-Route using intel compiler suites on Ursa. Testing is encouraged here to evaluate performance differences between `gfortran` and `intel` compilers for the Ensemble MVP work.  